### PR TITLE
docs: project vision, roadmap, and planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Derby Race Manager
+# DerbyTimer
 
-A Pinewood Derby race management system built with Bun, SQLite, and React. Designed for fast race-day operation with projection display support.
+> A turnkey Pinewood Derby race management system that any pack volunteer can set up, run, and tear down in under an hour — no internet required.
+
+Built with Bun, SQLite, and React. One laptop, one network, zero cloud dependencies.
 
 ## Features
 
@@ -242,6 +244,10 @@ derby-timer/
 - **Frontend**: React 19 + Tailwind CSS v4 + shadcn/ui
 - **Server**: `Bun.serve()` with hot reload and WebSocket broadcast
 - **Testing**: Bun test runner + Playwright
+
+## Roadmap
+
+See [Project Vision](docs/vision.md) for the full roadmap — real-time WebSocket display, hardware timer integration, Raspberry Pi deployment, setup wizard, cloud sync, and more.
 
 ---
 

--- a/docs/plans/cloud-sync.md
+++ b/docs/plans/cloud-sync.md
@@ -1,0 +1,89 @@
+# Cloud Sync & Remote Viewing
+
+## Problem
+
+Parents who couldn't attend (or are in the parking lot wrangling siblings) want to watch standings update in real time. Grandparents out of state want to see their kid's results. And after the event, printing certificates from the local network isn't possible.
+
+## Goal
+
+Optional, zero-config cloud connectivity so anyone with a link can watch the race live and print certificates from home.
+
+## Architecture
+
+The Pi/laptop is the source of truth. Cloud is a read-only mirror with a tunnel for live access.
+
+```
+┌──────────────┐         ┌──────────────────┐
+│  Pi / Laptop │ ──────→ │  Cloudflare      │ ──→ Public URL
+│  (DerbyTimer)│ tunnel  │  Tunnel / Tailscale│    derby.pack152.org
+└──────────────┘         └──────────────────┘
+```
+
+## Tunnel Options
+
+### Option A: Cloudflare Tunnel (Free, Recommended)
+- Install `cloudflared` on the Pi
+- One command: `cloudflared tunnel --url http://localhost:3000`
+- Gets a random `*.trycloudflare.com` URL — share via QR code
+- For a custom domain: configure once, runs automatically on boot
+- Free tier is sufficient for race-day traffic
+
+### Option B: Tailscale (For Tech-Savvy Packs)
+- Install Tailscale on the Pi and on viewer devices
+- Pi gets a stable `derby.tail12345.ts.net` address
+- More setup but more control. Good for multi-device pack setups.
+
+### Option C: Simple Relay Server (Self-Hosted)
+- A tiny VPS ($5/mo) runs a WebSocket relay
+- Pi connects out to the relay, relay forwards to viewers
+- Full control, no third-party dependencies
+- More work to maintain
+
+## What's Exposed Remotely
+
+| Route | Access | Notes |
+|-------|--------|-------|
+| `/display` | Public | Live standings + heat board |
+| `/certificates` | Public | All certificates for printing |
+| `/certificate/:id` | Public | Individual certificate |
+| `/api/events/:id/standings` | Public (read-only) | For custom integrations |
+| `/api/events/:id/heats` | Public (read-only) | Heat schedule |
+| Registration, Race Control | **Blocked** | Admin-only, local network |
+
+## Security
+
+- Auth plan (`docs/auth-plan.md`) already defines public vs admin routes
+- Cloudflare Tunnel can add access policies (email-based) for admin routes
+- Read-only API endpoints are safe to expose
+- No PII beyond racer names and den — acceptable for a pack event
+
+## QR Code Sharing
+
+On the Settings page, when cloud sync is enabled:
+- Generate a QR code for the public URL
+- "Share this with parents so they can watch from anywhere"
+- Print the QR code on a flyer for the event
+
+## Offline Resilience
+
+- Cloud sync is strictly optional. The app works 100% without it.
+- If the tunnel drops, local network continues working
+- Tunnel reconnects automatically when connectivity returns
+- No data is stored in the cloud — it's a passthrough
+
+## Implementation Steps
+
+1. **Detect connectivity** — check if the Pi has internet access
+2. **Tunnel setup** — install `cloudflared`, configure systemd service
+3. **Settings UI** — toggle cloud sync on/off, show public URL + QR code
+4. **Route filtering** — ensure admin routes are blocked via the tunnel
+5. **Status indicator** — show "Cloud: Connected" / "Cloud: Offline" in nav
+
+## Open Questions
+
+- Should we support push notifications (SMS/email) for race results?
+  - Nice to have but adds complexity. Start with a public URL and iterate.
+- How to handle the URL changing each time (random Cloudflare URL)?
+  - Option 1: Pack sets up a custom domain (e.g., `derby.pack152.org`)
+  - Option 2: Use a short URL service to create a stable redirect
+  - Option 3: Tailscale gives a stable hostname

--- a/docs/plans/display-pubsub.md
+++ b/docs/plans/display-pubsub.md
@@ -1,0 +1,128 @@
+# Display Pub/Sub — Real-Time Updates via WebSocket
+
+## Problem
+
+The projector display (`/display`) and volunteer phones currently poll the API on intervals. This creates lag — a heat finishes and it takes seconds for the display to update. With 100+ people watching the projector, that delay feels broken.
+
+## Goal
+
+Push updates to all connected clients the instant data changes. When a heat completes, every screen updates within 100ms.
+
+## Design
+
+### Channel-Based Pub/Sub
+
+Bun's built-in WebSocket support includes topic-based pub/sub. Clients subscribe to channels; the server publishes when data changes.
+
+```
+Channels:
+  event:{eventId}:heats      — heat status changes (started, completed)
+  event:{eventId}:standings   — standings recalculated
+  event:{eventId}:racers      — racer added/edited/inspected
+  event:{eventId}:control     — race control commands (start, reset)
+```
+
+### Client Behavior
+
+1. Connect to `ws://host/ws`
+2. Send `{ subscribe: ["event:abc:heats", "event:abc:standings"] }`
+3. Receive push messages: `{ channel: "event:abc:heats", data: { ... } }`
+4. On disconnect, auto-reconnect with exponential backoff
+
+### Server Behavior
+
+1. Accept WebSocket upgrades on `/ws`
+2. Track subscriptions per connection
+3. After any mutating API call (POST/PUT/DELETE), publish to relevant channels
+4. Payload is the same shape as the corresponding GET endpoint — clients can replace their local state directly
+
+### Message Format
+
+```ts
+// Server → Client
+interface WsMessage {
+  channel: string;
+  event: 'update' | 'delete' | 'refresh';
+  data: unknown; // matches the GET response shape
+  timestamp: number;
+}
+
+// Client → Server
+interface WsSubscribe {
+  subscribe?: string[];
+  unsubscribe?: string[];
+}
+```
+
+## Implementation Steps
+
+1. **WebSocket handler** — add `websocket` config to `Bun.serve()`, manage subscriptions
+2. **Publish helper** — `publish(channel, data)` function called from API routes
+3. **Client hook** — `useWebSocket(channels)` React hook that merges push data into local state
+4. **Migrate display.tsx** — replace `setInterval` polling with WebSocket subscription
+5. **Migrate main app** — `useApp()` context subscribes to relevant channels, calls `refreshData()` on push
+
+## Pre-Race Display: Countdown + Live Registration Ticker
+
+Before any heats run, the projector display has nothing to show. This is dead air during the busiest, most chaotic part of the event. Replace it with a **pre-race screen** that:
+
+1. Counts down to the scheduled first heat
+2. Shows new registrations scrolling in live as kids check in
+
+### Countdown
+
+```
+┌─────────────────────────────────────────────────┐
+│                                                  │
+│         Pack 152 Pinewood Derby 2026             │
+│                                                  │
+│              Racing starts in                    │
+│                                                  │
+│                  23:47                           │
+│                                                  │
+│              (2:00 PM)                           │
+│                                                  │
+└─────────────────────────────────────────────────┘
+```
+
+- Green → Amber (< 10 min) → Red + pulsing (< 3 min)
+- Once overdue with no heats: "Racing starts soon — preparing track..."
+- Switches automatically to the normal heat display when the first heat starts
+
+### Live Registration Ticker
+
+Below the countdown, new racers scroll in as they're registered at the desk — families in the audience see their kid's name appear on the projector:
+
+```
+┌─────────────────────────────────────────────────┐
+│  🏎  Dean Kim          Wolves     Car #101       │
+│  🏎  Lyile Bowers      Bears      Car #102       │
+│  🏎  Klara Kny-Flores  Webelos    Car #103       │
+│  ...                                             │
+└─────────────────────────────────────────────────┘
+```
+
+- New entries slide in from the bottom, older ones scroll up
+- Show den badge / den image thumbnail next to each name
+- Keep the last ~8–10 entries visible at once
+- Driven by the `event:{eventId}:racers` WebSocket channel — zero polling, instant update when a racer is added
+
+### Late-Start Warning
+
+If scheduled start time passes with no heats running, the admin UI (not the projector) shows:
+
+```
+⚠️ Start overdue by 18 min. Estimated finish: 5:20 PM.
+   Switch to Quick format to finish by 4:45 PM instead.
+```
+
+This keeps the pressure internal — families on the projector see "starting soon", not a stress indicator.
+
+## Open Questions
+
+- Should the WebSocket carry full payloads or just "invalidate" signals that trigger a fetch?
+  - Full payloads are simpler and faster for small data (standings, heat list)
+  - Invalidation is safer for large data or complex merging
+  - **Lean toward full payloads** — our data is small
+- How to handle stale clients? If a client reconnects after a long gap, it needs a full refresh
+  - On reconnect, client sends `{ refresh: true }` and server sends current state for all subscribed channels

--- a/docs/plans/hardware-api.md
+++ b/docs/plans/hardware-api.md
@@ -1,0 +1,96 @@
+# Hardware Timer API — External Finish-Line Integration
+
+## Problem
+
+Today, results are entered manually — a volunteer taps the placement order after each heat. This works but is slow, subjective, and can't capture millisecond finish times.
+
+Electronic timers (Micro Wizard K1, BestTrack, DIY IR sensors) can provide exact finish times and automatic placement ordering.
+
+## Goal
+
+Accept timing data from external hardware and auto-populate heat results. Support multiple hardware approaches without requiring code changes.
+
+## Architecture
+
+Two integration modes:
+
+### Mode 1: Serial Bridge (Existing)
+
+The K1 serial script (`scripts/serial-k1.ts`) already parses timer output. Extend it to POST results directly to the API.
+
+```
+Timer → USB Serial → K1 Script → POST /api/heats/:id/results
+```
+
+This keeps the serial parsing isolated. The script runs alongside the server, watches for race packets, and submits results via HTTP.
+
+### Mode 2: HTTP Push (Future Hardware)
+
+For WiFi-enabled timers or custom Arduino/ESP32 builds, accept results directly via HTTP.
+
+```
+POST /api/hardware/results
+Authorization: Bearer <hardware-token>
+Content-Type: application/json
+
+{
+  "source": "k1",
+  "lanes": [
+    { "lane": 1, "time_ms": 3001, "place": 1 },
+    { "lane": 2, "time_ms": 3047, "place": 2 },
+    { "lane": 3, "time_ms": 3128, "place": 3 },
+    { "lane": 4, "time_ms": 3241, "place": 4 }
+  ]
+}
+```
+
+The server matches this to the currently-running heat and populates results.
+
+## API Endpoints
+
+```
+POST /api/hardware/results     — submit race timing from hardware
+POST /api/hardware/start       — notify server that start gate opened
+GET  /api/hardware/status      — current heat info for hardware display
+POST /api/hardware/register    — register a hardware device (returns token)
+```
+
+## Race Flow with Hardware
+
+1. Volunteer clicks "Start Heat" in Race Control → server marks heat as `running`
+2. Start gate opens → timer begins counting
+3. Cars cross finish line → timer records times per lane
+4. Timer sends results via serial bridge or HTTP push
+5. Server receives results, marks heat `complete`, updates standings
+6. WebSocket push notifies all clients → display updates instantly
+
+## Serial Bridge Enhancement
+
+Extend the existing K1 script to:
+- Watch for the currently-running heat via `GET /api/hardware/status`
+- On race packet, POST results to `/api/hardware/results`
+- Show confirmation in terminal: "Heat R1·H3 results submitted"
+- Handle errors gracefully (no running heat, mismatched lane count)
+
+```bash
+# Start the bridge
+bun run serial:k1:bridge --port /dev/tty.usbserial-XXXX --server http://localhost:3000
+```
+
+## Target Supported Timers
+
+| Timer | Connection | Status |
+|-------|-----------|--------|
+| Micro Wizard K1/K1CS | USB Serial (9600 8N1) | Serial script exists |
+| BestTrack | USB Serial | Parser needed |
+| DIY IR Break-Beam | ESP32 WiFi HTTP | HTTP push ready |
+| Pi or Arduino + Sensors | USB Serial | Parser needed |
+
+## Open Questions
+
+- Should hardware results auto-confirm, or should the Race Control volunteer review before confirming?
+  - **Lean toward auto-confirm** with an "undo last" button — speed matters on race day
+- How to handle DNF (Did Not Finish) lanes? Timer may report no time for a lane
+  - Timer reports missing lanes → server fills those as DNF (last place)
+- What if hardware results arrive when no heat is running?
+  - Queue them with a warning, let the volunteer match them manually

--- a/docs/plans/heat-scheduling.md
+++ b/docs/plans/heat-scheduling.md
@@ -1,0 +1,535 @@
+# Heat Scheduling — Algorithms, Configuration & Time Estimation
+
+> **See also**: [Race Day 2026 Post-Mortem](./race-day-2026-analysis.md) — analysis of our first real event (43 cars, 74 heats, too long).
+
+## Current Implementation
+
+### What We Have Today
+
+The current planner (`src/race/heat-planner.ts`) uses an **adaptive greedy algorithm** with a rolling queue:
+
+1. **Rolling queue** — only 2–3 heats are generated ahead ("lookahead"). As heats complete, new ones are planned using updated standings. This lets late results influence upcoming matchups.
+
+2. **Lane balancing** — each racer's goal is to run in every lane `rounds` times (default: 1 round = every lane once). The planner tracks per-racer lane counts and prioritizes racers/lanes with the highest unmet need.
+
+3. **Participant selection** — for each heat, a "seed racer" (most urgent need) is chosen, then companions are selected by scoring:
+   - Lane coverage need (strong preference for racers who need the selected lanes)
+   - Repeated matchup penalty (avoid pairing the same racers repeatedly)
+   - Performance proximity (group racers with similar win rates together)
+   - Total assignments balance (don't over-schedule any racer)
+
+4. **Lane assignment** — once participants are chosen, lanes are assigned via branch-and-bound search minimizing: lane-need penalties, historical lane repeats, and global lane usage imbalance.
+
+5. **Elimination rounds** — after all racers complete a full lane cycle, the field is cut to ~half (rounded up). Survivors are ranked by: wins DESC → losses ASC → avg time ASC → heats run DESC → car number ASC. This repeats until 2 finalists remain.
+
+### Strengths
+- Adaptive: uses current standings to influence matchups
+- Fair lane coverage: every car hits every lane
+- Elimination narrows the field, keeping event duration manageable
+- Rolling queue means the full schedule isn't locked in — flexible
+
+### Weaknesses
+- Not a known optimal schedule (like Perfect-N) — no mathematical guarantee of head-to-head balance
+- Greedy heuristic may produce suboptimal pairings compared to pre-computed charts
+- No configurability — the algorithm is fixed, no user choice of strategy
+- No time estimation — volunteers can't predict when the event will end
+- **Factory Line Feel** — The focus on efficiency can make the event feel monotonous and "over-optimized" for throughput rather than fun.
+- The early test file (`tests/heat-generation.test.ts`) tests a *different* inline algorithm, not the actual `heat-planner.ts`
+
+### Scoring Model Today
+
+Standings are **placement-based**: 1st place = win, everything else = loss. Times (`time_ms`) are optional — stored when hardware provides them, used only as a 3rd tiebreaker in standings: `wins DESC → losses ASC → avg_time_ms ASC`.
+
+This means two very different cars can have identical win/loss records even though one is consistently 0.5 seconds faster. Times exist in the data model but don't meaningfully affect outcomes.
+
+---
+
+## Event Pacing & Experience
+
+### Optimizing for Fun
+Lessons from 2026 show that a high heat cadence (e.g., 47s) is efficient but can feel like a "chore" for volunteers and participants. The system should allow for **intentional pacing**:
+- **Commentary Buffers**: Add a configurable delay or "wait for operator" state between heats to allow for MC commentary, cheers, and "hero moments" for the kids.
+- **Atmosphere over Throughput**: For large fields, prioritize a format that keeps everyone involved longer (no early cuts) even if it means fewer heats per car.
+
+### Start-Time Awareness
+The system should track the "Scheduled Start" vs. "Actual First Heat".
+- **Late Start Warning**: If registration/inspection runs long (e.g., more than 30 mins past scheduled start), surface a warning and suggest a shorter race format (like "Quick" mode) to ensure the event ends on time.
+- **Registration stations**: Plan for high-capacity check-in (4+ stations) to prevent start delays.
+
+---
+
+## Scheduling Approaches in the Derby World
+
+### 1. Perfect-N (Pre-Computed Chart)
+
+The gold standard. A pre-computed chart where:
+- Every car races in each lane the **exact same number of times**
+- Every car races against every other car the **exact same number of times**
+- Heat assignments are evenly distributed through the event
+
+**Constraints**: Only works for specific car/lane combinations. For 4 lanes, Perfect-N charts exist for car counts like 4, 8, 13 — but not all numbers. Pioneered by Stan Pope and Bill Young.
+
+**Pros**: Mathematically provably fair. Zero lane bias. Zero matchup bias.
+**Cons**: Rigid — can't adapt to race results. Not all car counts are supported. Must be pre-computed.
+
+*Sources: [stanpope.net](https://stanpope.net/ppngen.html), [Scouting Magazine](https://scoutingmagazine.org/2015/11/scheduling-strategies-transform-packs-next-pinewood-derby/)*
+
+### 2. Partial Perfect-N (PPN)
+
+A relaxation of Perfect-N that works for nearly all car/lane combinations:
+- Each car races in each lane the same number of times ✓
+- Head-to-head matchup counts differ by **at most 1** (not exactly equal)
+
+Unsupported edge cases exist (e.g., 5 lanes + 20 cars) but can be worked around with byes.
+
+**Pros**: Works for almost any field size. Still very fair. Pre-computed = fast.
+**Cons**: Still rigid (no adaptation to results). Slightly less fair than Perfect-N on matchups.
+
+*Sources: [stanpope.net PPN Generator](https://stanpope.net/ppngen.html)*
+
+### 3. Lane Rotation (Simple Round-Robin)
+
+Cars rotate through lanes sequentially. Each car runs in every lane once.
+Points scored per heat (1st = 1 point, 2nd = 2, etc.), lowest total wins.
+
+**Pros**: Dead simple to understand and implement. Every car races the same amount.
+**Cons**: No control over who races whom. Some cars may face the fastest competitors disproportionately. Back-to-back racing for some cars.
+
+*Sources: [Scouting Magazine](https://scoutingmagazine.org/2015/11/scheduling-strategies-transform-packs-next-pinewood-derby/)*
+
+### 4. Adaptive Greedy (Current DerbyTimer)
+
+Our current approach. See "What We Have Today" above.
+
+**Pros**: Adapts to results. Flexible field size. Built-in elimination. Rolling queue.
+**Cons**: No mathematical fairness guarantee. Hard to predict total duration.
+
+### 5. Double Elimination (Bracket)
+
+Traditional bracket — lose twice and you're out.
+
+**Pros**: Exciting, familiar format. Shortest total time. Clear progression.
+**Cons**: Most kids only race 2–3 times. Many eliminated early → bored spectators. No lane balancing. Requires a timing system or subjective judging.
+
+*Sources: [Scouting Magazine](https://scoutingmagazine.org/2015/11/scheduling-strategies-transform-packs-next-pinewood-derby/)*
+
+### 6. Stearns Method
+
+Pre-selection round using a structured schedule to narrow a large field to 7–13 finalists, then Perfect-N for the final round. Good for 30+ car events.
+
+**Pros**: Handles large fields efficiently. Final round is provably fair.
+**Cons**: Two-phase adds complexity. Early rounds are less fair.
+
+*Sources: [stanpope.net](https://stanpope.net/pwraces.html)*
+
+---
+
+## Comparison Matrix
+
+### Scheduling Methods
+
+| Method | Lane Fairness | Matchup Fairness | Adapts to Results | Works for Any Field Size | Total Heats (50 cars, 4 lanes) | Complexity |
+|--------|:---:|:---:|:---:|:---:|:---:|:---:|
+| Perfect-N | Perfect | Perfect | No | Limited sizes | 50 | Pre-computed |
+| Partial Perfect-N | Perfect | Near-perfect | No | Nearly all | 50 | Pre-computed |
+| Lane Rotation | Perfect | Random | No | Yes | 50 | Simple |
+| Adaptive Greedy (ours) | Good | Good | Yes | Yes | ~50 + elimination | Medium |
+| Double Elimination | None | None | By design | Yes | ~26–30 | Simple |
+| Stearns + Perfect-N | Perfect (finals) | Mixed | No | Yes | ~60–70 | Two-phase |
+
+### Scoring × Scheduling Interactions
+
+Not all scoring modes pair equally well with all scheduling modes:
+
+| Scoring Mode | Best Scheduling Pairing | Why |
+|---|---|---|
+| Placement (win/loss) | Adaptive Greedy or Bracket | Matchups matter — who you race against determines your record. Adaptive grouping by skill level makes this fairer. |
+| Points (place-based) | Chart (PPN) or Lane Rotation | Points accumulate fairly when every car races equal heats. Pre-computed schedules guarantee this. |
+| Time (average) | Any — matchups irrelevant | Since you're racing the clock, scheduling only needs to ensure equal heat counts. Lane coverage still matters for handicap fairness. |
+| Handicapped Time | Chart (PPN) recommended | Handicaps correct for lane bias, but only if every car has run enough lanes for the correction to be meaningful. PPN guarantees equal lane exposure. |
+
+---
+
+## Proposed Configurable Scheduling
+
+### User-Facing Options
+
+When generating heats, volunteers choose a **scheduling mode** via the existing Race Format page:
+
+#### Mode 1: "Balanced" (Default — Current Behavior, Enhanced)
+Our adaptive greedy algorithm. Good default for most packs.
+
+- **Config**: Rounds per cycle (default 1 = every lane once)
+- **Config**: Finals format:
+  - **None** (default for 20+ cars) — one lane cycle, standings are final
+  - **Championship heat** — top 4 do a quick runoff after the main round
+  - **Full elimination** — current behavior, halving the field each round (best for < 20 cars)
+- **Config**: Lookahead (2 or 3 heats visible ahead)
+- **Best for**: Packs wanting a fair, adaptive race with manageable duration
+- **Lesson from 2026**: With 43 cars, full elimination produced 74 heats (~74 min). Single round + championship heat would have been ~53 heats (~53 min).
+
+#### Mode 2: "Chart" (Perfect-N / Partial Perfect-N)
+Pre-computed schedule. Every car races every lane exactly N times. No elimination — all cars race the full schedule, final standings decided by cumulative record.
+
+- **Config**: Rounds (1–3, i.e., race each lane 1–3 times)
+- **Behavior**: Entire schedule is generated upfront (no rolling queue)
+- **Best for**: Packs wanting provably fair, fully predictable schedules
+- **Implementation**: Port PPN chart generation or embed pre-computed tables for common car/lane combos (4–6 lanes, 4–60 cars)
+
+#### Mode 3: "Quick" (Reduced Schedule)
+Same adaptive algorithm but with a target heat count instead of full lane coverage. Each car races a fixed number of times (e.g., 3 heats regardless of lane count), then standings decide winners.
+
+- **Config**: Heats per car (default 3)
+- **Behavior**: Trades fairness for speed. Not every car will hit every lane.
+- **Best for**: Large packs (40+ cars) that need to finish in under an hour, or events with time constraints
+
+#### Mode 4: "Bracket" (Double Elimination)
+Classic bracket format. Lose twice, you're out.
+
+- **Config**: None needed
+- **Behavior**: System generates matchups round by round
+- **Best for**: Small fields (< 16 cars), exhibition events, time-crunched events
+
+### Configuration UI
+
+Add to the existing Race Format page (`RaceFormatView.tsx`):
+
+```
+┌─────────────────────────────────────────────┐
+│ Scheduling Mode                              │
+│ ┌─────────┐ ┌─────────┐ ┌───────┐ ┌───────┐│
+│ │Balanced │ │ Chart   │ │ Quick │ │Bracket││
+│ │(Default)│ │         │ │       │ │       ││
+│ └─────────┘ └─────────┘ └───────┘ └───────┘│
+│                                              │
+│ Estimated Duration: ~45 min                  │
+│ Total Heats: ~50                             │
+│ Heats per Car: 4                             │
+│ ████████████░░░░░░░░░░░░░░ 38% complete      │
+└─────────────────────────────────────────────┘
+```
+
+---
+
+## Time Estimation & Progress Bar
+
+### Time-per-Heat Model
+
+Derby heat turnaround varies by crew efficiency:
+
+| Pace | Time per Heat | Description |
+|------|:---:|---|
+| Relaxed | 90s | First-time crew, lots of chatter |
+| Normal | 60s | Typical volunteer crew |
+| Fast | 45s | Experienced crew, smooth staging |
+| Expert | 30s | Electronic timer, rehearsed volunteers |
+
+### Estimation Formula
+
+```
+totalHeats = f(cars, lanes, mode, rounds)
+estimatedMinutes = totalHeats × secondsPerHeat / 60
+```
+
+For each mode:
+- **Balanced**: `totalHeats ≈ ceil(cars × lanes / lanes) × eliminationRounds` — sum of heats across elimination stages
+- **Chart (PPN)**: `totalHeats = ceil(cars / lanes) × lanes × rounds`  (exact, since the full schedule is pre-computed)
+- **Quick**: `totalHeats = ceil(cars × heatsPerCar / lanes)`
+- **Bracket**: `totalHeats ≈ 2 × cars - 1` (double elimination)
+
+### Live Progress Bar
+
+Once racing begins, show a progress bar on the Heat Schedule and Race Control views:
+
+```ts
+interface RaceProgress {
+  completedHeats: number;
+  totalHeats: number;           // known or estimated
+  avgSecondsPerHeat: number;    // rolling average of actual heats
+  estimatedMinutesRemaining: number;
+  percentComplete: number;
+}
+```
+
+- **Before first heat**: use the configured pace assumption (default: 60s)
+- **After 3+ heats**: switch to rolling average of actual elapsed time per heat
+- **Display**: `████████░░░░░░░ 12/50 heats · ~38 min remaining`
+- **For adaptive modes** where total heats aren't fully known: estimate based on remaining racers needing runs + elimination projections
+
+### API Addition
+
+```
+GET /api/events/:eventId/progress
+→ { completedHeats, totalHeats, avgSecondsPerHeat, estimatedMinutesRemaining, percentComplete }
+```
+
+`totalHeats` is exact for Chart mode and estimated for adaptive modes (based on current field size and remaining lane needs).
+
+---
+
+## Scoring Modes — When You Have Times
+
+When electronic timing is available, times open up fundamentally different (and fairer) ways to determine winners. The scoring mode should be configurable per event.
+
+### Mode A: Placement-Based (Current Default)
+
+Each heat produces a winner (1st place) and losers (everyone else). Standings rank by win count. Times are a tiebreaker only.
+
+```
+Heat result:  Lane 1: 3.001s (1st)  Lane 2: 3.047s (2nd)  Lane 3: 3.128s (3rd)  Lane 4: 3.241s (4th)
+Scoring:      Lane 1: WIN           Lane 2: LOSS           Lane 3: LOSS           Lane 4: LOSS
+```
+
+**Pros**: Simple, no timer required, works with manual judging
+**Cons**: A 3.002s car and a 3.999s car both get "LOSS" — no credit for being close. Who you race against matters more than how fast you are.
+
+### Mode B: Points-Based (Place Points)
+
+Award points per finish position. Lower is better (golf scoring). Common in lane-rotation events.
+
+```
+Heat result:  Lane 1: 3.001s (1st)  Lane 2: 3.047s (2nd)  Lane 3: 3.128s (3rd)  Lane 4: 3.241s (4th)
+Scoring:      Lane 1: 1 pt          Lane 2: 2 pts          Lane 3: 3 pts          Lane 4: 4 pts
+```
+
+Standings: total points, lowest wins. Ties broken by average time.
+
+**Pros**: Second place means something. Still works without times (just placement order).
+**Cons**: Still doesn't capture *how much* faster — a 0.001s margin and a 1.000s margin both give the same point gap.
+
+### Mode C: Time-Based (Best/Average Time)
+
+Standings ranked purely by cumulative or average finish time. Placement within a heat doesn't matter — only the clock.
+
+```
+Heat result:  Lane 1: 3.001s  Lane 2: 3.047s  Lane 3: 3.128s  Lane 4: 3.241s
+Scoring:      Each car's time added to their running total/average
+```
+
+Standings: average time across all heats, lowest wins.
+
+**Pros**: Most objective — the fastest car wins regardless of matchups. Who you race against is irrelevant. Eliminates the "unlucky bracket" problem.
+**Cons**: **Requires electronic timing** — can't do this with manual judging. Lane bias matters more (some lanes are consistently faster). Less exciting for spectators (no "winners" per heat).
+
+### Mode D: Handicapped Time (Time-Based + Lane Correction)
+
+Same as time-based, but each car's raw time is adjusted by a per-lane handicap to correct for lane bias.
+
+```
+Lane handicaps:  Lane 1: +0.000s  Lane 2: +0.012s  Lane 3: -0.008s  Lane 4: +0.021s
+Raw time:        Lane 1: 3.001s   Lane 2: 3.047s    Lane 3: 3.128s   Lane 4: 3.241s
+Adjusted time:   Lane 1: 3.001s   Lane 2: 3.035s    Lane 3: 3.136s   Lane 4: 3.220s
+```
+
+Standings: average *adjusted* time, lowest wins.
+
+**Pros**: The fairest possible scoring. Neutralizes track imperfections. Makes every heat directly comparable.
+**Cons**: Requires calibration (see Lane Handicapping below). More complex to explain to parents. Requires electronic timing.
+
+### Recommended Default
+
+- **No timer**: Mode A (placement) — it's all you can do
+- **With timer**: Mode C (time-based) — fairer than placement, simpler than handicapped
+- **With timer + calibration**: Mode D (handicapped time) — maximum fairness
+
+The scoring mode selector appears on the Race Format page alongside the scheduling mode selector.
+
+### Data Model Changes for Scoring Modes
+
+```sql
+-- Add to events or planning_state:
+scoring_mode TEXT DEFAULT 'placement'  -- 'placement' | 'points' | 'time' | 'handicapped_time'
+
+-- Add to standings (new columns):
+total_points INTEGER,        -- for points-based mode
+adjusted_avg_time_ms REAL,   -- for handicapped mode
+best_time_ms REAL,           -- useful across all modes
+```
+
+The `recalculateStandingsForRacer()` method in `results.ts` would branch on `scoring_mode` to compute the appropriate ranking fields. The standings query `ORDER BY` clause changes per mode:
+
+| Mode | ORDER BY |
+|------|----------|
+| Placement | `wins DESC, losses ASC, avg_time_ms ASC` |
+| Points | `total_points ASC, avg_time_ms ASC` |
+| Time | `avg_time_ms ASC` |
+| Handicapped | `adjusted_avg_time_ms ASC` |
+
+---
+
+## Lane Handicapping
+
+### The Problem
+
+No track is perfectly level or symmetrical. Lane 3 might be 0.015s faster than Lane 1 due to slight tilt, rail friction, or guide wire tension. Over many heats, this systematic bias accumulates and can change the outcome.
+
+Perfect-N scheduling mitigates this by ensuring every car races every lane equally — but it doesn't *eliminate* the bias from each individual time measurement. If you're doing time-based scoring, lane bias directly corrupts results.
+
+### Calibration Process
+
+Run a **calibration set** before the event (or use the first few heats of the event itself):
+
+#### Option 1: Dedicated Calibration Runs (Recommended)
+
+Use 1–3 "calibration cars" (consistent, fast cars that a volunteer can re-stage quickly). Each calibration car runs every lane 2–3 times.
+
+```
+Calibration car A:
+  Lane 1: 3.012s, 3.015s, 3.010s  → avg 3.012s
+  Lane 2: 3.025s, 3.028s, 3.022s  → avg 3.025s
+  Lane 3: 3.005s, 3.008s, 3.003s  → avg 3.005s
+  Lane 4: 3.030s, 3.033s, 3.028s  → avg 3.030s
+
+Track baseline (average of all lanes): 3.018s
+
+Lane handicaps (offset from baseline):
+  Lane 1: +0.006s (slightly slow)
+  Lane 2: -0.007s (slightly fast → add time to compensate)
+  Lane 3: +0.013s (fastest lane → biggest correction)
+  Lane 4: -0.012s (slowest lane)
+```
+
+Wait — correction direction: if Lane 3 is the fastest, cars in Lane 3 have an advantage. To neutralize: **subtract** the lane's advantage from each raw time, so a car in the fast lane gets a slightly *higher* adjusted time.
+
+Corrected formula: `adjusted_time = raw_time - lane_offset` where `lane_offset = lane_avg - track_avg`. A negative offset (slow lane) means we subtract a negative number (adding time back), a positive offset (fast lane) means we subtract time (penalizing the advantage).
+
+Actually simpler: `adjusted_time = raw_time + handicap` where `handicap = track_avg - lane_avg`. Fast lanes get a positive handicap (penalty), slow lanes get a negative handicap (bonus).
+
+#### Option 2: Auto-Calibrate from Race Data
+
+After N heats (e.g., 10+), compute lane averages from all recorded times. Since many different cars race in each lane, the averages converge toward the lane's true speed characteristic.
+
+```
+After 20 heats:
+  Lane 1 avg across all cars: 3.145s (82 runs)
+  Lane 2 avg across all cars: 3.158s (80 runs)
+  Lane 3 avg across all cars: 3.138s (81 runs)
+  Lane 4 avg across all cars: 3.162s (83 runs)
+
+Track baseline: 3.151s
+
+Auto-derived handicaps:
+  Lane 1: +0.006s
+  Lane 2: -0.007s
+  Lane 3: +0.013s
+  Lane 4: -0.011s
+```
+
+This is less accurate early on (small sample) but requires zero extra setup. Can be recalculated continuously as more data comes in.
+
+### Data Model
+
+```sql
+-- New table
+CREATE TABLE lane_handicaps (
+  event_id TEXT NOT NULL,
+  lane_number INTEGER NOT NULL,
+  handicap_ms REAL NOT NULL DEFAULT 0,  -- added to raw_time
+  sample_count INTEGER DEFAULT 0,        -- how many runs this is based on
+  source TEXT DEFAULT 'manual',          -- 'manual' | 'calibration' | 'auto'
+  updated_at TEXT,
+  PRIMARY KEY (event_id, lane_number)
+);
+```
+
+### API
+
+```
+GET  /api/events/:eventId/lane-handicaps
+POST /api/events/:eventId/lane-handicaps          — set manually or from calibration
+POST /api/events/:eventId/lane-handicaps/auto      — recalculate from race data
+POST /api/events/:eventId/lane-handicaps/calibrate — run calibration mode
+```
+
+### UI: Calibration Page
+
+Accessible from Settings or Race Format:
+
+```
+┌─────────────────────────────────────────────┐
+│ Lane Calibration                             │
+│                                              │
+│ Lane 1:  +0.006s  ██████░░  (12 samples)    │
+│ Lane 2:  -0.007s  ███████░  (11 samples)    │
+│ Lane 3:  +0.013s  █████████ (13 samples)    │
+│ Lane 4:  -0.011s  ███████░░ (10 samples)    │
+│                                              │
+│ Source: Auto-calibrated from 20 heats        │
+│                                              │
+│ [Recalculate]  [Reset to Zero]  [Manual Edit]│
+└─────────────────────────────────────────────┘
+```
+
+### How Handicaps Affect Results Display
+
+When handicapped scoring is active:
+- Race Control shows both **raw time** and **adjusted time** per lane
+- Standings show **adjusted average** as the primary sort
+- Individual heat results show the handicap applied: `3.047s → 3.040s (−0.007)`
+- Certificate stats use adjusted times
+
+---
+
+## Implementation Plan
+
+### Phase 1: Document & Stabilize Current Algorithm
+1. Align test file (`heat-generation.test.ts`) with actual `heat-planner.ts` exports
+2. Add property-based tests: lane coverage, no duplicate racers per heat, balanced assignments
+3. Add time estimation API endpoint using current adaptive mode
+
+### Phase 2: Progress Bar & Time Estimation
+1. Track `started_at` / `completed_at` per heat for actual pacing data
+2. Implement `GET /api/events/:eventId/progress`
+3. Add progress bar to HeatsView and RaceConsoleView
+4. Show estimated duration on the generate-heats confirmation dialog
+
+### Phase 3: Scoring Mode Selection
+1. Add `scoring_mode` to events or planning_state table
+2. Branch `recalculateStandingsForRacer()` by scoring mode
+3. Update standings query ORDER BY per mode
+4. Add scoring mode selector to RaceFormatView
+5. Show scoring-mode-appropriate columns in standings display
+
+### Phase 4: Lane Handicapping
+1. Create `lane_handicaps` table and migration
+2. Implement auto-calibration from race data (after 10+ heats)
+3. Implement manual calibration UI
+4. Wire handicaps into adjusted time calculation in standings
+5. Show raw + adjusted times in Race Control when handicaps are active
+
+### Phase 5: Scheduling Mode Selection
+1. Add `scheduling_mode` column to events or planning_state table
+2. Update RaceFormatView with mode selector and per-mode config
+3. Implement "Quick" mode (simplest new mode — just cap heats per car)
+4. Pass mode config through generate-heats API
+
+### Phase 6: Chart Mode (PPN)
+1. Implement PPN chart generator (or embed pre-computed tables for 4-lane, 4–60 cars)
+2. Generate full schedule upfront (no rolling queue)
+3. Show full schedule preview before starting
+
+### Phase 7: Bracket Mode
+1. Implement double-elimination bracket generator
+2. Bracket visualization UI
+3. Auto-advance after each round
+
+---
+
+## Open Questions
+
+- Should Chart mode allow mid-race additions (late registrations)?
+  - **Lean no** — PPN charts are pre-computed. Late additions would require regeneration and voiding previous results. Show a warning instead.
+- Should we support the Stearns method as a separate mode?
+  - **Defer** — it's a two-phase approach (Stearns → Perfect-N finals). Complex to implement. The "Balanced" mode with elimination achieves a similar outcome.
+- How to handle uneven car counts in Chart mode?
+  - Use byes (empty lane) when car count doesn't divide evenly into lanes. The PPN algorithm handles this.
+- Should the time estimate account for breaks?
+  - Show raw racing time. Volunteers know their own break schedule. Optionally add a "break buffer" config later.
+- Should handicaps recalculate continuously or lock after calibration?
+  - **Lean toward lock after calibration** — auto-recalculating mid-event could shift standings retroactively, which feels unfair. Show a "recalibrate" button the volunteer can press manually between rounds.
+- Should we retroactively adjust old results when handicaps are set or updated?
+  - **Yes** — recompute all adjusted times from raw times + current handicaps. Raw times are never modified.
+- Can time-based scoring work with elimination rounds?
+  - Yes, but the elimination cut should use adjusted average time instead of wins/losses. This is actually simpler — just sort by time and cut the bottom half.
+- What if only some heats have times (mixed manual/electronic)?
+  - Fall back to placement scoring for heats without times. Or: require all heats to have times for time-based modes — show a warning if a heat is submitted without times in time/handicapped mode.

--- a/docs/plans/multi-year.md
+++ b/docs/plans/multi-year.md
@@ -1,0 +1,99 @@
+# Multi-Year Results & History
+
+## Problem
+
+Every year the derby is a fresh start. There's no way to look back and say "You've improved your average time by 0.3 seconds since last year!" or "This is your 3rd derby — you're a veteran!"
+
+## Goal
+
+Track racer participation across years. Show improvement trends, all-time records, and returning racer recognition.
+
+## Data Model Changes
+
+The current model ties racers to a single event. To support multi-year:
+
+### Option A: Racer Identity Table (Recommended)
+
+```sql
+-- New table: persistent racer identity across events
+CREATE TABLE racer_identities (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,           -- canonical name
+  den TEXT,                     -- current den (updates each year)
+  first_event_id TEXT,          -- when they first raced
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Add to existing racers table:
+ALTER TABLE racers ADD COLUMN identity_id TEXT REFERENCES racer_identities(id);
+```
+
+When registering a racer, the app suggests matches from previous years: "Is this the same Dean Kim who raced in 2025?"
+
+### Option B: Name Matching (Simpler, Less Reliable)
+
+Match by name across events. Works for small packs but breaks with common names or spelling variations.
+
+**Recommendation**: Start with Option A. The identity table is simple and explicit.
+
+## Features
+
+### Returning Racer Recognition
+- During registration: "Welcome back! This is Dean's 3rd Pinewood Derby!"
+- On certificates: "3-Year Derby Veteran"
+- On the display page: veteran badge next to returning racers
+
+### Personal History on Racer Profile
+- List of past events with results
+- Best-ever finish (overall and den)
+- Time trend chart (if times were captured)
+- "Personal best" callout when they beat their record
+
+### All-Time Records
+- Fastest time ever recorded (by event, overall)
+- Most wins in a single event
+- Most heats raced career total
+- Pack Hall of Fame page
+
+### Year-Over-Year Comparison
+- Average time this year vs last year
+- Win rate improvement
+- "Most improved racer" award candidate
+
+## UI Additions
+
+### Racer Profile (Enhanced)
+```
+┌─────────────────────────────────────────┐
+│ Dean Kim — Wolves Den                    │
+│ 🏆 3-Year Veteran                       │
+│                                          │
+│ This Year: 2nd Place Overall, 8W-4L      │
+│ Last Year: 5th Place Overall, 6W-6L      │
+│ Career:    3 Events, 22W-14L             │
+│                                          │
+│ Personal Best: 3.001s (2026)             │
+│ Average Time:  3.15s → 3.08s (improving!)│
+└─────────────────────────────────────────┘
+```
+
+### Hall of Fame Page
+- `/hall-of-fame` — all-time records and notable achievements
+- Projector-friendly for display during the event
+- Celebrate returning racers and pack history
+
+## Migration Strategy
+
+- Existing single-event data stays untouched
+- `racer_identities` table is created on first multi-year use
+- Volunteer can manually link past racers during registration
+- No automatic linking — too error-prone for kids with similar names
+
+## Open Questions
+
+- How to handle racers who change dens year to year? (They age up through ranks)
+  - Identity table stores current den; past events keep the den they had at the time
+- Should we allow merging two identity records if a duplicate was created?
+  - Yes, with a simple "merge" action in settings
+- What's the minimum data needed from past events if times weren't captured?
+  - Win/loss record and placement are sufficient. Times are a bonus.

--- a/docs/plans/pi-deployment.md
+++ b/docs/plans/pi-deployment.md
@@ -1,0 +1,119 @@
+# Raspberry Pi Turnkey Deployment
+
+## Problem
+
+Setting up a laptop with Bun, cloning the repo, and running the server is fine for a developer. For a pack volunteer? Too many steps, too many things to go wrong.
+
+## Goal
+
+Flash an SD card once. Every year, plug in the Pi, wait 30 seconds, and the race server is running. Under $200 for the complete hardware kit.
+
+## Hardware Bill of Materials
+
+| Item | Approx Cost | Notes |
+|------|------------|-------|
+| Raspberry Pi 4 (4GB) or Pi 5 | $55–80 | Pi 4 is sufficient, Pi 5 is snappier |
+| 32GB microSD card | $8 | Class 10 / A2 recommended |
+| USB-C power supply | $10 | Official Pi power supply |
+| Case with fan | $10 | Passive cooling works too |
+| Ethernet cable (6ft) | $5 | For connecting to router/switch |
+| USB WiFi AP dongle (optional) | $15 | If you want the Pi to be the WiFi hotspot |
+| **Total** | **$88–128** | Excluding timer hardware |
+
+## Software Stack
+
+```
+Raspberry Pi OS Lite (64-bit, headless)
+  └── Bun runtime (ARM64 binary)
+       └── DerbyTimer (bundled, single binary or source)
+            └── SQLite database (local file)
+```
+
+### Boot Sequence
+
+1. Pi powers on → OS boots (10–15 seconds)
+2. Systemd service starts DerbyTimer (2–3 seconds)
+3. mDNS announces `derby.local` on the network
+4. Server is ready at `http://derby.local:3000`
+
+## Image Build Process
+
+Use a reproducible image builder (like `pi-gen` or a simple shell script):
+
+```bash
+# On a build machine:
+1. Start from Raspberry Pi OS Lite base image
+2. Install Bun runtime
+3. Copy DerbyTimer source + node_modules (or pre-bundled)
+4. Configure systemd service (auto-start on boot)
+5. Configure mDNS (avahi-daemon, hostname: derby)
+6. Configure WiFi AP mode (optional, via hostapd)
+7. Disable unnecessary services (bluetooth, swap)
+8. Set up automatic database backup to /boot partition
+9. Write image to SD card
+```
+
+### Systemd Service
+
+```ini
+[Unit]
+Description=DerbyTimer Race Server
+After=network.target
+
+[Service]
+Type=simple
+User=derby
+WorkingDirectory=/opt/derby-timer
+ExecStart=/usr/local/bin/bun src/index.ts
+Restart=always
+RestartSec=3
+Environment=PORT=3000
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Network Modes
+
+### Mode A: Existing WiFi Network (Simplest)
+- Pi connects to the venue's WiFi via ethernet or pre-configured WiFi
+- Volunteers join the same network and access `derby.local:3000`
+- Projector laptop connects via HDMI + WiFi
+
+### Mode B: Pi as WiFi Hotspot (Most Portable)
+- Pi runs `hostapd` to create a WiFi network: `PinewoodDerby` (no password or simple one)
+- Volunteers connect to this network
+- Pi serves DHCP via `dnsmasq`
+- No internet needed — fully self-contained
+- Downside: parents can't be on venue WiFi and derby WiFi simultaneously
+
+### Mode C: Separate Travel Router (Recommended)
+- Bring a small travel router (GL.iNet, ~$25)
+- Pi connects via ethernet
+- Router creates WiFi network
+- Best of both worlds: reliable WiFi + Pi stays wired
+
+## Year-to-Year Usage
+
+1. **Before race day**: Plug in Pi, connect to network, open `derby.local:3000`, create new event
+2. **Race day**: Pi is already configured. Plug in, wait 30s, go.
+3. **After race day**: Unplug Pi, put it in the derby box with the track. Database persists on SD card.
+4. **Next year**: Plug in the same Pi. Previous year's data is still there. Create a new event.
+
+## Update Strategy
+
+- Pi has no internet on race day → no auto-updates
+- Before race day, volunteer can: `ssh derby@derby.local` → `cd /opt/derby-timer && git pull && bun install`
+- Or: re-flash the SD card with a new image (nuclear option)
+- Future: USB-stick update — drop a `.tar.gz` on a USB drive, Pi detects and updates on boot
+
+## Open Questions
+
+- Should the Pi image include the timer serial bridge auto-started?
+  - Only if a serial device is detected at boot. Otherwise manual start.
+- How to handle database corruption from sudden power loss?
+  - SQLite WAL mode handles this well. Add `PRAGMA journal_mode=WAL` on startup.
+  - Periodic checkpoint to `/boot` partition (FAT32, readable from any computer).
+- Should we pre-bundle with `bun build --compile` for faster startup?
+  - Yes, single-binary deployment is simpler. Test on ARM64 first.

--- a/docs/plans/race-day-2026-analysis.md
+++ b/docs/plans/race-day-2026-analysis.md
@@ -1,0 +1,189 @@
+# Race Day 2026 — Post-Mortem Analysis
+
+## Event Facts
+
+- **Event**: Pinewood Derby 2026 (February 28, 2026)
+- **Cars**: 43 inspected racers
+- **Track**: 4 lanes
+- **Algorithm**: Adaptive greedy with elimination (default settings)
+- **Status**: `racing` (Round 3 never completed)
+- **Scheduled start**: 2:15 PM local
+- **Racing start**: 3:27 PM local (UTC+1)
+- **Start delay**: 1 hour 12 minutes
+- **Last heat**: 5:02 PM local
+- **Total elapsed**: ~94 minutes (including racing and inter-round break)
+- **Note**: All timestamps in the database are UTC; local time = UTC+1
+
+## What Happened
+
+| Round | Racers | Heats | Heats/Racer | Avg heat cadence | Notes |
+|-------|--------|-------|:-----------:|:-----------:|-------|
+| R1 | 43 | 49 | 4–7 (avg 4.5) | 47s | Full lane cycle |
+| — | — | — | — | **37 min break** | Announcing cuts, staging confusion |
+| R2 | 22 | 23 | 4–5 (avg 4.1) | 47s | Survivors run another full lane cycle |
+| R3 | 6 | 2 | incomplete | — | Event abandoned |
+| **Total** | | **74** | | | |
+
+**Actual measured heat cadence: 47 seconds** start-to-start on average (min 14s, max 149s, excluding the inter-round break). That is not 2 minutes — the cars ran fast. The 2-minute perception came from the 37-minute break between Round 1 and Round 2 making everything feel slow.
+
+### Timeline (local time, UTC+1)
+
+| Time | Event |
+|------|-------|
+| 2:15 PM | **Scheduled Start** |
+| 3:27 PM | First heat starts (1:12 delay for registration/inspection) |
+| 4:06 PM | Heat 48 completes (Round 1 nearly done) |
+| 4:24 PM | Heat 49 marked complete (no `started_at` — likely run without clicking Start) |
+| 4:24–5:01 PM | **37-minute gap** — announcing who was cut, confusion, staging Round 2 |
+| 5:01 PM | Round 2 starts |
+| 5:02 PM | Last recorded heat (Round 2 ends, Round 3 abandoned) |
+
+## Why So Many Heats?
+
+### 1. Full lane coverage is expensive with 43 cars
+
+For 43 cars on a 4-lane track, every car needs 4 heats (one per lane). That's 43×4 = 172 racer-lane assignments. At 4 per heat, the theoretical minimum is **43 heats**. The adaptive algorithm used 49 (14% overhead due to greedy fill decisions — some racers ran 5–7 heats while others ran exactly 4).
+
+**49 heats for Round 1 alone is already a long event.** This is the irreducible cost of "every car races every lane" fairness for a 43-car field.
+
+### 2. Elimination re-runs the entire process
+
+After Round 1, the field was cut to 22 racers (top half). Those 22 then ran **another full lane cycle** — 23 more heats. Then cut to 6, started another cycle.
+
+Each elimination round is essentially a complete mini-derby. The elimination system assumes that re-running full lane coverage is necessary for fair ranking at each stage. For 43 cars, this nearly doubled the total:
+
+```
+Without elimination:  49 heats (~50 min)
+With elimination:     49 + 23 + 2 = 74 heats (~74 min) and incomplete
+```
+
+### 3. Eliminated kids sat idle
+
+21 racers were cut after Round 1. They had nothing to do during the 23 heats of Round 2 — roughly 25 minutes of waiting. For elementary school kids, that's a long time.
+
+### 4. Round 1 racer-lane distribution was uneven
+
+| Heats run | Racers |
+|:---------:|:------:|
+| 4 | 26 |
+| 5 | 14 |
+| 6 | 2 |
+| 7 | 1 |
+
+In a perfect schedule, all 43 racers would run exactly 4 heats. The greedy algorithm over-assigned 17 racers to fill lanes, creating 21 extra racer-lane slots (193 used vs 172 minimum). This added ~5 heats to Round 1.
+
+Some racers also appeared in the same lane twice (21 duplicate lane assignments), meaning the "every lane once" goal wasn't perfectly met — a few racers hit some lanes twice while others hit them once.
+
+## Root Causes
+
+1. **The 37-minute inter-round break was the biggest single problem.** The app gave no warning that cutting to Round 2 would require announcing eliminations, finding which kids were still eligible, explaining the cut to families, and re-staging cars. This chaos was entirely predictable but not surfaced to volunteers in advance.
+2. **No duration guardrails** — the algorithm optimizes for fairness without any constraint on total heat count or event duration. Volunteers had no idea how long the event would take when they pressed "Generate Heats."
+3. **Elimination is always-on** — there's no option to skip elimination rounds or choose a lighter finals format.
+4. **Full lane coverage per elimination round** — each round demands every surviving car race every lane again. This is O(N) heats per round.
+5. **Greedy fill creates overhead** — the heuristic over-schedules some racers to avoid empty lanes, adding ~14% more heats than the theoretical minimum.
+6. **No scoring without times** — the K1 timer wasn't used, so no times were captured. Standings ran purely on win/loss. See "Standings Model" below.
+7. **Monotony from over-optimization** — The focus on clearing 74+ heats quickly made the racing feel like a chore. The speed was efficient but the atmosphere felt monotonous because we were just "trying to get through it" rather than enjoying the event.
+
+## What We'd Change
+
+### For a 43-car / 4-lane event, target ~50 heats (under 1 hour):
+
+**Option A: Single round, no elimination** — 49 heats. Final standings from one lane cycle determine all placements. Every kid races the whole event.
+
+**Option B: Single round + championship heat** — 49 heats for everyone, then 1–4 extra heats for the top 4 finishers. Total: ~53 heats. Gives a "finals" moment without re-running a full cycle. 21 kids still watch, but only for ~4 minutes.
+
+**Option C: Reduced coverage** — each car races 3 heats instead of 4 (skip one lane). Total: ~33 heats. Trades some lane fairness for a much shorter event. With electronic timing and lane handicaps, skipping a lane matters less.
+
+### Configuration needed in the app:
+
+1. **Elimination toggle** — on/off per event
+2. **Finals format** — "Full elimination" (current) vs "Championship heat" (top N do a quick runoff) vs "None" (standings are final after one round)
+3. **Duration target** — "Aim for under X minutes" that adjusts heats-per-car downward for large fields
+4. **Progress visibility** — show "Heat 32 of ~49 · ~17 min remaining" so volunteers know where they are
+
+## Standings Model: Win/Loss, Not Points
+
+The current standings are **purely win/loss**. There are no points. Placement in a heat is binary: 1st = win, anything else = loss.
+
+```
+Ranking order:  wins DESC → losses ASC → avg_time_ms ASC (tiebreaker only)
+```
+
+From the actual 2026 data, the top of the standings shows the problem clearly:
+
+| Name | Wins | Losses | Heats | Win Rate |
+|------|:----:|:------:|:-----:|:--------:|
+| Guhan puviyarrasan | 6 | 2 | 8 | 75% |
+| Julios oberwagner | 4 | 4 | 8 | 50% |
+| Maximilian Bodner | 4 | 4 | 8 | 50% |
+| Holland Scott | 4 | 4 | 8 | 50% |
+
+Racer 1 clearly dominated. But racers 2–4 are indistinguishable — all 4W/4L — and since no times were captured, there's no tiebreaker. Three kids tied for 2nd with no way to separate them.
+
+**The structural problem with win/loss-only scoring:**
+- A car that consistently finishes 2nd (very fast, always beat by one car) has the same record as a car that finishes dead last every heat
+- With 43 cars and 4-per-heat, only 1 car wins each heat — 75% of participants get a loss even if they ran well
+- No times = no tiebreaker = ties everywhere in the middle of the standings
+
+**What time-based scoring would have changed:**
+A car finishing 2nd in 3.002s vs a car finishing 3rd in 3.8s both get "loss" today. With time scoring, the 3.002s car ranks far above the 3.8s car regardless of heat matchups. This matters most for the kids in the middle of the pack.
+
+## Awards Ceremony & Car Voting
+
+After racing, cars were displayed and families voted on favorites using **paper ballots**. Awards were given for categories like Most Creative.
+
+**Problems with paper:**
+- Votes weren't captured digitally — no record exists
+- Can't appear on certificates
+- Counting ballots takes time and a volunteer
+- No live excitement on the projector while voting is open
+
+**The 37-minute inter-round break** would have been a natural voting window — cars were already staged, families were milling around, everyone had their phones. Instead it was dead time.
+
+**Planned solution**: Phone-based voting via QR code on the projector. Families tap their favorite car, live vote counts tick up on the display, MC closes voting when ready, winner stored in the database and appears as a badge on their certificate.
+
+→ [Voting Plan](./voting.md)
+
+## Lessons for the Scheduling Plan
+
+These findings should feed directly into the configurable scheduling plan (`heat-scheduling.md`):
+
+### Duration & Estimation
+- **Show the estimate before generating heats.** Volunteers pressed "Generate" with no idea they were signing up for 74+ heats.
+- **47 seconds is the real heat cadence** for this crew — not 60s or 90s. Use actual measured data after a few heats.
+- **Budget time for inter-round breaks.** Elimination cuts require announcements, family communication, and car re-staging. Add at least 15–20 minutes per elimination round to estimates.
+- **Surface a "you started late" warning.** Racing didn't start until 3:27 PM local. With a 94-minute event that puts the finish at 5:02 PM — late for a pack event. If the event starts after a configurable time (e.g., after 2 PM) and the estimate runs past a configurable end time (e.g., 5 PM), warn the volunteer and suggest a shorter format.
+
+### Logistics & Registration
+
+Registration and inspection happened **at the same desk simultaneously** — `updated_at` on racers is nearly identical to `created_at` for all 43 kids. The desk was fast.
+
+**Actual timeline breakdown:**
+| Window | What | Duration |
+|--------|------|----------|
+| 2:23–2:56 PM | Registration + weigh-in together | 33 min |
+| 2:56–3:27 PM | Car staging ("easy pull" order), family announcements, deliberate wait | **30 min** |
+| 3:27 PM | First heat | — |
+
+The 30-minute staging gap was intentional — cars had to be physically arranged on the staging table in heat order, and volunteers addressed the crowd. The app has no visibility into this window at all; it just sees silence between last inspection and first heat.
+
+**One outlier**: Julios (car #1) had his record updated at 3:47 PM — 84 minutes after creation. Likely a mid-race correction.
+
+**What the line felt like**: Registration peaked at 16 kids in 10 minutes (2:30–2:40 PM). With a 10+ person queue and 1–2 stations, individuals waited 6–10 minutes to reach the desk even though the desk itself was fast (~37s per racer).
+
+**Next year's fixes:**
+1. **Pre-load the roster** before race day (names, dens, car numbers) so desk check-in is a 5-second confirmation, not data entry — cuts the 33-min window roughly in half.
+2. **Stage cars earlier** — don't wait until registration closes to start staging. Do it in parallel as kids check in.
+3. **Time-box the staging gap** — set a hard "heats begin at X" target and announce it. The app should surface this: "First heat scheduled for 3:00 PM — 4 minutes away."
+4. **The line had 10+ people most of the time.** More stations help with perceived wait, even if throughput is already fine.
+
+### Scheduling Defaults
+- **Optimize for Fun**: Efficiency is important, but not at the cost of the experience. The fast cadence felt like a factory line. Next time, aim for a pace that allows for commentary, cheers, and "moments" for the kids.
+- **For 25+ cars, default to single round, no elimination.** Round 1 alone (49 heats × 47s = ~38 min) was a fair and complete race. Elimination added 37+ more minutes of racing plus 37 minutes of chaos.
+- **Elimination should be opt-in** with a clear preview of what it adds ("This will add ~22 more heats and ~25 minutes, plus time to announce cuts").
+- **Championship heat** (top 4 run 1 extra heat) gives drama without the full second round.
+
+### Scoring
+- **Wire up the K1 timer next year.** Without times, mid-pack standings are meaningless ties. With times, every placement is uniquely ranked.
+- **Consider points-based scoring** (1st=4pts, 2nd=3pts, 3rd=2pts, 4th=1pt) as a no-timer alternative that gives credit for 2nd/3rd place instead of treating everything non-1st as a loss.
+- **Winning a heat in a field of 4 is not the same as winning a heat of 2.** The current model doesn't account for heat size. Worth considering in any future scoring revamp.

--- a/docs/plans/sensor-guide.md
+++ b/docs/plans/sensor-guide.md
@@ -1,0 +1,103 @@
+# Hardware Compatibility
+
+## Approach
+
+DerbyTimer doesn't teach you how to build sensors — it ships firmware images and serial parsers so supported hardware just works out of the box.
+
+For each supported device, we provide:
+- A **flashable firmware image** (for programmable boards like ESP32/Arduino)
+- Or a **serial parser** (for commercial timers like Micro Wizard K1)
+
+Plug in, flash (if needed), and the hardware talks to DerbyTimer automatically via the [Hardware API](./hardware-api.md).
+
+## Compatibility Matrix
+
+| Device | Connection | Integration | Status |
+|--------|-----------|-------------|--------|
+| Micro Wizard K1/K1CS | USB Serial (9600 8N1) | Serial parser (built-in) | Supported |
+| BestTrack | USB Serial | Serial parser | Planned |
+| ESP32 (any dev board) | WiFi HTTP or USB Serial | Flash DerbyTimer firmware | Planned |
+| Arduino Uno/Nano | USB Serial | Flash DerbyTimer firmware | Planned |
+| Raspberry Pi Pico | USB Serial | Flash DerbyTimer firmware | Planned |
+
+## Commercial Timers
+
+### Micro Wizard K1/K1CS
+
+No firmware flash needed — these have their own firmware. DerbyTimer includes a serial parser that reads their output format.
+
+**What you need**: K1 timer + DB9-to-USB serial adapter (~$10)
+
+**Connect**:
+```bash
+bun run serial:k1:bridge --port /dev/tty.usbserial-XXXX --server http://localhost:3000
+```
+
+Existing docs: [`electronics/k1-serial-script.md`](../electronics/k1-serial-script.md), [`electronics/serial-bus-test-checklist.md`](../electronics/serial-bus-test-checklist.md)
+
+### BestTrack
+
+Same idea — serial parser, no firmware flash. Protocol documentation exists in the timer community. Parser not yet implemented.
+
+## Flashable Firmware Images
+
+For programmable boards (ESP32, Arduino, Pico), we provide pre-built firmware that:
+
+1. Reads finish-line sensors (IR break-beam, laser, or photoresistor — whatever you've wired)
+2. Detects start gate (microswitch or reed switch)
+3. Sends results to DerbyTimer via the [Hardware API](./hardware-api.md)
+4. Requires zero code from the user — just flash and configure lane count
+
+### ESP32 Firmware
+
+Flash via USB:
+```bash
+# Download and flash (one-time)
+bun run firmware:flash --board esp32 --port /dev/tty.usbserial-XXXX
+
+# Or download the .bin from releases and flash with esptool
+esptool.py write_flash 0x0 derby-timer-esp32.bin
+```
+
+On boot, the ESP32 creates a WiFi config portal. Connect, enter the DerbyTimer server address, and it's ready.
+
+**Supported sensor wiring**: Any break-beam or switch-based sensor connected to GPIO pins. The firmware is configurable for 2–6 lanes and supports IR, laser, or mechanical sensors.
+
+### Arduino Firmware
+
+Flash via Arduino IDE or CLI:
+```bash
+bun run firmware:flash --board arduino-nano --port /dev/tty.usbserial-XXXX
+```
+
+Arduino connects via USB serial (same as commercial timers). The serial parser auto-detects DerbyTimer firmware vs commercial timer output.
+
+### Raspberry Pi Pico Firmware
+
+Drag-and-drop `.uf2` file:
+1. Hold BOOTSEL button, plug in USB
+2. Drag `derby-timer-pico.uf2` to the mounted drive
+3. Pico reboots and starts sending results over USB serial
+
+## Testing Any Hardware
+
+```bash
+# Verify serial communication
+bun run serial:k1:harness --port /dev/tty.usbserial-XXXX --races 1
+
+# Verify HTTP communication (ESP32 WiFi mode)
+curl -X POST http://localhost:3000/api/hardware/results \
+  -H "Content-Type: application/json" \
+  -d '{"lanes":[{"lane":1,"time_ms":3001},{"lane":2,"time_ms":3047}]}'
+```
+
+Full checklist: [`electronics/serial-bus-test-checklist.md`](../electronics/serial-bus-test-checklist.md)
+
+## Adding Support for New Hardware
+
+To add a new commercial timer, write a serial parser in `scripts/serial-*.ts` that:
+1. Opens the serial port at the correct baud rate
+2. Parses race timing lines into `{ lane, time_ms, place }` objects
+3. POSTs results to `/api/hardware/results`
+
+To add a new microcontroller, create firmware that speaks the DerbyTimer serial protocol or HTTP API.

--- a/docs/plans/setup-config.md
+++ b/docs/plans/setup-config.md
@@ -1,0 +1,111 @@
+# Setup & Configuration
+
+## Problem
+
+Today, configuration is scattered across environment variables, code defaults, and the event creation form. A new volunteer setting up the system has to know about `PORT`, database locations, and timer settings.
+
+## Goal
+
+A first-run wizard and settings page that handles all configuration through the UI. Plug in the laptop, open the browser, answer a few questions, and you're racing.
+
+## First-Run Wizard
+
+On first launch (no events in database), show a setup wizard instead of the empty event list:
+
+### Step 1: Event Setup
+- Event name (e.g., "Pack 152 Pinewood Derby 2026")
+- Date
+- Number of lanes (default 4)
+- **Scheduled start time** — when do you want the first heat to run? (e.g., 2:00 PM)
+- **Target end time** — when do you need to be done? (e.g., 4:30 PM)
+
+These times feed the projector display countdown and the late-start warning. See [Display Plan](./display-pubsub.md) for how the countdown works.
+
+### Step 2: Network Info
+- Display the server's local IP address and QR code
+- "Share this with volunteers so they can connect on their phones"
+- Auto-detect WiFi interface and show the right address
+
+### Step 3: Timer Hardware (Optional)
+- "Do you have an electronic timer?"
+  - **No** → manual entry mode (current default)
+  - **Yes, USB serial** → show detected serial ports, let them pick one, run a quick test
+  - **Yes, WiFi/HTTP** → show the hardware endpoint URL and token
+
+### Step 3b: Awards (Optional)
+
+Pick which people's choice awards you want families to vote on. Check the ones you want, add your own, or skip entirely.
+
+```
+☑  Most Creative Car
+☑  Best Paint Job
+☐  Funniest Car
+☐  Most Aerodynamic (looks)
+☐  Most Scout-Like
+☐  Most Colorful
+☐  Best Name
+☐  Pack Spirit Award
+─────────────────────
++  Add your own...
+```
+
+Selected awards are created as voting categories automatically. The MC opens and closes voting from the race control screen during the awards ceremony.
+
+→ See [Voting Plan](./voting.md) for how voting works during the event.
+
+### Step 4: Ready
+- Summary of settings
+- **Roster Preload** (Optional): Upload a CSV of racer names and dens so check-in is a tap, not a form. See format below.
+- "Start Registration" button → goes to registration view
+
+### Roster CSV Format
+
+```csv
+name,den,car_number
+Dean Kim,Wolves,101
+Lyile Bowers,Bears,102
+```
+
+`car_number` is optional — can be assigned at the desk. `den` maps to the known den images.
+
+## Settings Page
+
+Accessible from the nav bar (gear icon). Sections:
+
+### General
+- Event name and date (editable)
+- Lane count (only changeable before heats are generated)
+- App port (requires restart)
+
+### Network
+- Current server IP + QR code
+- Display page URL for projector
+- Certificate page URL
+
+### Timer
+- Current mode: Manual / Serial / HTTP
+- Serial port selection and test button
+- Hardware token for HTTP mode
+
+### Data
+- **Roster Preload**: Upload CSV to add racers in bulk.
+- **Registration Capacity**: Note to set up 4+ stations for large events.
+- Export event data (JSON)
+- Import event data
+- Reset event (with confirmation)
+- Database backup/restore
+
+## Implementation Notes
+
+- Settings stored in a `settings` table in SQLite (key-value)
+- First-run detection: check if any events exist
+- QR code: use a lightweight library or generate SVG inline
+- Serial port detection: `SerialPort.list()` via Bun's native module support or a system call to `ls /dev/tty.*`
+- Network detection: `os.networkInterfaces()` to find the WiFi/ethernet IP
+
+## Open Questions
+
+- Should settings be per-event or global?
+  - **Lean toward global** with per-event overrides for lane count
+- How to handle mid-event lane count changes?
+  - Block after heats are generated. If they need to change, delete heats first.

--- a/docs/plans/voting.md
+++ b/docs/plans/voting.md
@@ -1,0 +1,160 @@
+# Car Voting — People's Choice Awards
+
+## Background
+
+After racing at the 2026 derby, cars were displayed and kids/families voted on favorites using paper ballots. The results weren't captured digitally, so they couldn't appear on certificates.
+
+## Goal
+
+Replace paper ballots with phone-based voting. Families scan a QR code, vote on their phone, results display live on the projector, and winners are stored so certificates can include the award.
+
+## Voting Categories
+
+Categories are chosen during the setup wizard (Step 3b) from a preset list, or typed in custom. Whatever is selected becomes the active award categories for the event.
+
+**Built-in presets:**
+
+| Award | Notes |
+|-------|-------|
+| Most Creative Car | Most commonly used — on by default |
+| Best Paint Job | |
+| Funniest Car | |
+| Most Aerodynamic (looks) | |
+| Most Scout-Like | |
+| Most Colorful | |
+| Best Name | |
+| Pack Spirit Award | |
+
+Custom awards can be added in setup or later from the Settings page before voting opens. Categories can't be changed once voting has started.
+
+Each voter picks one car per category. A racer can win multiple categories.
+
+## Flow
+
+### For Families (Phone)
+
+1. Projector shows a QR code: `http://derby.local/vote`
+2. Family opens the page — sees a grid of car photos with racer names
+3. Taps their favorite — one vote per device per category
+4. Confirmation: "Vote counted for Dean Kim!"
+5. Can change vote until voting closes
+
+### For the MC / Admin
+
+1. Opens `/vote/admin` — sees live vote counts per car, per category
+2. When ready, clicks "Close Voting" — locks results
+3. Winners are announced, stored in the database
+4. Certificates for winners automatically include the award badge
+
+### On the Projector
+
+During the voting window, `/display` shows a live leaderboard:
+
+```
+┌─────────────────────────────────────────┐
+│  🏆 Most Creative — Live Votes          │
+│                                          │
+│  1. Dean Kim          ████████  14 votes │
+│  2. Klara Kny-Flores  █████     9 votes  │
+│  3. Flora Kny-Flores  ███       6 votes  │
+│  ...                                     │
+│                                          │
+│  Scan to vote →  [QR code]              │
+└─────────────────────────────────────────┘
+```
+
+Live updates via WebSocket — vote counts tick up in real time as families vote.
+
+## Data Model
+
+```sql
+-- Award categories defined per event
+CREATE TABLE award_categories (
+  id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL REFERENCES events(id),
+  name TEXT NOT NULL,          -- "Most Creative", "Best Paint Job"
+  voting_open INTEGER DEFAULT 1,
+  created_at TEXT
+);
+
+-- One row per vote (device-based deduplication)
+CREATE TABLE votes (
+  id TEXT PRIMARY KEY,
+  category_id TEXT NOT NULL REFERENCES award_categories(id),
+  racer_id TEXT NOT NULL REFERENCES racers(id),
+  device_token TEXT NOT NULL,  -- fingerprint stored in localStorage
+  created_at TEXT,
+  UNIQUE(category_id, device_token)  -- one vote per device per category
+);
+
+-- Winners (set when voting closes)
+CREATE TABLE award_winners (
+  id TEXT PRIMARY KEY,
+  category_id TEXT NOT NULL REFERENCES award_categories(id),
+  racer_id TEXT NOT NULL REFERENCES racers(id),
+  vote_count INTEGER,
+  created_at TEXT
+);
+```
+
+## API
+
+```
+GET  /api/events/:eventId/award-categories     — list categories + voting status
+POST /api/events/:eventId/award-categories     — create a category (admin)
+POST /api/vote                                 — cast a vote { category_id, racer_id, device_token }
+GET  /api/events/:eventId/vote-counts          — live counts per racer per category (public)
+POST /api/award-categories/:id/close           — close voting + record winners (admin)
+GET  /api/events/:eventId/award-winners        — final winners (used by certificates)
+```
+
+## Vote Integrity
+
+- **One vote per device per category** — enforced by `UNIQUE(category_id, device_token)` in the database
+- `device_token` is a random UUID generated on first visit, stored in `localStorage`
+- Not cryptographically secure (families could vote twice on different browsers) but appropriate for a pack event — this isn't an election
+- Admin can see vote counts live and spot obvious stuffing
+
+## Certificate Integration
+
+When a racer has won an award category, their certificate gains an award badge:
+
+```
+┌──────────────────────────────────────┐
+│  [existing cert content]             │
+│                                      │
+│  🎨 Most Creative Car  ← new badge  │
+└──────────────────────────────────────┘
+```
+
+The `Certificate` component checks `award_winners` for the racer's ID and renders a badge for each category won. Multiple awards stack.
+
+## Timing
+
+Voting works best during the **inter-round break** or **awards ceremony** — cars are on display, families are milling around, everyone has their phones out. The QR code on the projector is the invite.
+
+For the 2026 event, this would have filled the 37-minute gap between Round 1 and Round 2 productively — families engage with the cars, the projector shows something interesting, and by the time racing resumes the winner is known.
+
+## Display Phases
+
+The `/display` page needs a new phase concept:
+
+| Phase | Trigger | Display shows |
+|-------|---------|---------------|
+| `pre-race` | No heats yet | Countdown + registration ticker |
+| `racing` | Heats in progress | Heat board + standings |
+| `voting` | MC opens voting | Live vote leaderboard + QR code |
+| `awards` | Voting closed | Winners announced |
+| `complete` | Event marked done | Final standings + certificate QR |
+
+Phase is set by the MC via the admin UI, not automatically — they control the pacing of the ceremony.
+
+## Implementation Order
+
+1. Data model + migrations
+2. `POST /api/vote` + `GET /api/events/:id/vote-counts`
+3. `/vote` phone page — car grid, tap to vote, confirmation
+4. Admin close voting + record winners
+5. Projector live leaderboard (WebSocket)
+6. Certificate badge integration
+7. QR code on projector display during voting phase

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,116 @@
+# DerbyTimer — Project Vision
+
+> A turnkey Pinewood Derby race management system that any pack volunteer can set up, run, and tear down in under an hour — no internet required.
+
+## Where We Are
+
+DerbyTimer handles the core race-day loop today:
+
+- **Registration** — volunteers add racers on their phones, snap car photos, run inspection
+- **Heat scheduling** — balanced lane rotation generated automatically
+- **Race control** — start heats, record placements, optional time capture
+- **Live display** — projector-optimized standings and heat boards via dedicated `/display` page
+- **Certificates** — scout-themed printable certificates with tiered achievements and den rankings
+
+The app runs as a single Bun process with SQLite. One laptop, one network, zero cloud dependencies.
+
+## Where We're Going
+
+### 1. Real-Time Display via WebSocket Pub/Sub
+
+Replace polling with push-based updates so the projector display, volunteer phones, and parent devices all stay in sync instantly.
+
+→ [Display Pub/Sub Plan](./plans/display-pubsub.md)
+
+### 2. Hardware Timer Integration
+
+Accept electronic finish times from sensors (Micro Wizard K1, BestTrack, DIY IR gates) via serial or HTTP, so results flow directly into the app with millisecond accuracy.
+
+→ [Hardware API Plan](./plans/hardware-api.md)
+
+### 3. Setup & Configuration
+
+A first-run wizard and settings page so volunteers can configure lanes, event details, network, and timer hardware without touching config files.
+
+→ [Setup & Config Plan](./plans/setup-config.md)
+
+### 4. Raspberry Pi Turnkey Deployment
+
+Flash an SD card, plug in power and ethernet, and you have a race server. Under $200 all-in, reusable year after year.
+
+→ [Pi Deployment Plan](./plans/pi-deployment.md)
+
+### 5. Cloud Sync & Remote Viewing
+
+Optional tunnel (Cloudflare Tunnel / Tailscale) so parents at home can review standings live on their devices or after the event athome. Print certificates from any browser, not just the local network.
+
+→ [Cloud Sync Plan](./plans/cloud-sync.md)
+
+### 6. Cloud Store Multi-Year Results & History
+
+Track racer progress across years. "This is your 3rd derby!" Show improvement trends, all-time records, returning racer profiles.
+
+→ [Multi-Year Tracking Plan](./plans/multi-year.md)
+
+### 7. Hardware Compatibility
+
+Compatibility matrix and flashable firmware images for supported timers and microcontrollers. Plug in, flash, race.
+
+→ [Hardware Compatibility](./plans/sensor-guide.md)
+
+### 8. People's Choice Voting
+
+Families vote on car awards (Most Creative, Best Paint Job) from their phones during the awards ceremony. Live vote counts on the projector, winners stored and printed on certificates.
+
+→ [Voting Plan](./plans/voting.md)
+
+### 9. Configurable Heat Scheduling
+
+Multiple scheduling algorithms (adaptive greedy, Perfect-N charts, quick mode, bracket), configurable per event. Live progress bar with time-to-completion estimate.
+
+→ [Heat Scheduling Plan](./plans/heat-scheduling.md)
+
+## Design Principles
+
+These hold across all future work:
+
+1. **Offline-first** — everything works without internet. Cloud features are opt-in extras.
+2. **Volunteer-proof** — if it takes training, it's too complex. Big buttons, clear labels, one action per screen.
+3. **Projector-optimized** — high contrast, large text, readable from 30 feet away.
+4. **Portable** — fits in a backpack. Laptop + Pi + timer + a few cables.
+5. **Cheap** — under $300 for the complete hardware stack (excluding laptop).
+6. **Adaptive** — works with no timer (manual entry), a basic timer (serial), or a full sensor rig.
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    Bun Server                        │
+│  ┌──────────┐  ┌──────────┐  ┌───────────────────┐  │
+│  │  Routes   │  │ WebSocket│  │  Serial/Hardware  │  │
+│  │ (API+HTML)│  │ Pub/Sub  │  │  Bridge           │  │
+│  └────┬─────┘  └────┬─────┘  └────────┬──────────┘  │
+│       │              │                 │              │
+│       └──────────────┼─────────────────┘              │
+│                      │                                │
+│              ┌───────┴───────┐                        │
+│              │    SQLite     │                        │
+│              └───────────────┘                        │
+└─────────────────────────────────────────────────────┘
+        │              │              │
+   ┌────┴───┐    ┌─────┴────┐   ┌────┴─────┐
+   │ Phones │    │ Projector│   │  Timer   │
+   │(WiFi)  │    │ Display  │   │ Hardware │
+   └────────┘    └──────────┘   └──────────┘
+```
+
+## Existing Documentation
+
+| Doc | Purpose |
+|-----|---------|
+| [Race Day Plan](./race-day-plan.md) | Original implementation spec — data model, UI flow, heat scheduling |
+| [Certificate Plan](./certificate-plan.md) | Certificate tiering, layout, scout theming |
+| [Auth Plan](./auth-plan.md) | Cookie-based auth for admin vs public routes |
+| [K1 Serial Script](./electronics/k1-serial-script.md) | Micro Wizard K1 serial communication |
+| [Serial Test Checklist](./electronics/serial-bus-test-checklist.md) | Hardware validation steps |
+| [Race Day 2026 Analysis](./plans/race-day-2026-analysis.md) | Post-mortem from Feb 2026 derby — timing data, heat count analysis, lessons |


### PR DESCRIPTION
## Summary
- Add `docs/vision.md` as the top-level roadmap linking 9 feature plans
- Add 10 planning docs covering: real-time display, hardware API, setup wizard, Pi deployment, cloud sync, multi-year tracking, hardware compatibility, car voting, heat scheduling, and a race-day 2026 post-mortem
- Update README: rename to DerbyTimer, add tagline from vision, link to roadmap

## Planning docs
| Doc | Topic |
|-----|-------|
| `display-pubsub.md` | WebSocket real-time updates + pre-race countdown |
| `hardware-api.md` | Serial + HTTP timer integration |
| `setup-config.md` | First-run wizard + settings page |
| `pi-deployment.md` | Raspberry Pi turnkey deployment |
| `cloud-sync.md` | Optional remote access via tunnel |
| `multi-year.md` | Cross-year racer history |
| `sensor-guide.md` | Device compatibility matrix + firmware |
| `voting.md` | Phone-based people's choice awards |
| `heat-scheduling.md` | Algorithms, scoring modes, lane handicaps |
| `race-day-2026-analysis.md` | Post-mortem from Feb 2026 derby |

## Test plan
- [ ] All internal markdown links resolve (verified — 14 cross-references checked)
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)